### PR TITLE
Liden/patch prompt playground

### DIFF
--- a/pg_text_query/prompt.py
+++ b/pg_text_query/prompt.py
@@ -41,13 +41,13 @@ def _describe_cols(cols: t.List[t.Dict[t.Any, t.Any]], include_types: bool) -> s
 
 
 def _describe_table(schema_name: str, table_name: str) -> str:
-    return table_name if schema_name == "public" else f"{schema_name}.{table_name}"
+    return f'"{table_name}"' if schema_name == "public" else f'"{schema_name}"."{table_name}"'
 
 
 def _describe_schema(schema: t.Dict[t.Any, t.Any], include_types: bool = True) -> str:
     return "\n".join(
         [
-            f"-- Table {_describe_table(schema['name'], t['name'])}, columns = [{_describe_cols(t['columns'], include_types)}]"
+            f"-- Table = {_describe_table(schema['name'], t['name'])}, columns = [{_describe_cols(t['columns'], include_types)}]"
             for t in schema["tables"]
         ]
     )

--- a/test/test_logic/test_prompt.py
+++ b/test/test_logic/test_prompt.py
@@ -101,7 +101,7 @@ class PromptTestCase(unittest.TestCase):
         expected = "\n".join(
             [
                 "-- Language PostgreSQL",
-                "-- Table penguins, columns = [bill_length_mm double precision, bill_depth_mm double precision, flipper_length_mm bigint, body_mass_g bigint, year bigint, species text, island text, sex text]",
+                "-- Table = \"penguins\", columns = [bill_length_mm double precision, bill_depth_mm double precision, flipper_length_mm bigint, body_mass_g bigint, year bigint, species text, island text, sex text]",
                 "-- A PostgreSQL query to return 1 and a PostgreSQL query for how many penguins are there?",
                 "SELECT 1;",
             ]


### PR DESCRIPTION
- previously, whether app.py ran successfully depended on whether it was run from the project root or the playground subdir. This is fixed.
- fixes some issues with caching/persistence of connection details and database schema details. Previously, the schema from the database was overwritten by the example schema when one tried to actually generate sql.
- modifies the `_describe_table` function to quote table and schema names